### PR TITLE
URL encode email addresses before sending the GET request

### DIFF
--- a/ZeroBounceApi.js
+++ b/ZeroBounceApi.js
@@ -26,7 +26,7 @@ class ZeroBounceApi {
          * @return - a JSONObject with all of the information for the specified email
          * */
         this.validate = function(email, ip_address){
-            var uri = baseUrl + "/validate" + "?api_key=" + apiKey + "&email=" + email + "&ip_address=" + ip_address;
+            var uri = baseUrl + "/validate" + "?api_key=" + apiKey + "&email=" + encodeURIComponent(email) + "&ip_address=" + ip_address;
             get.open('GET', uri, false);
             get.send();
             if (get.readyState == 4 && get.status == 200) {


### PR DESCRIPTION
emails containing `+` character (which are valid) otherwise don't get validated.